### PR TITLE
Fix RSI division by zero

### DIFF
--- a/utils/indicators.py
+++ b/utils/indicators.py
@@ -1,10 +1,20 @@
 import pandas as pd
 
+
+EPSILON = 1e-10
+
 def calculate_rsi(data, window=14):
+    """Calculate the Relative Strength Index (RSI).
+
+    This implementation avoids division by zero by adding a small epsilon value
+    to the denominator when computing the relative strength (RS).
+    """
+
     delta = data.diff()
     gain = (delta.where(delta > 0, 0)).rolling(window=window).mean()
     loss = (-delta.where(delta < 0, 0)).rolling(window=window).mean()
-    rs = gain / loss
+
+    rs = gain / (loss + EPSILON)
     return 100 - (100 / (1 + rs))
 
 def calculate_macd(data, fast=12, slow=26):


### PR DESCRIPTION
## Summary
- add epsilon constant
- use epsilon in `calculate_rsi` to avoid division by zero

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6838fe2cd8048326933ef01854a406de